### PR TITLE
Fixed error with the case where an output file is an empty string

### DIFF
--- a/src/helpers/error_printer.c
+++ b/src/helpers/error_printer.c
@@ -21,3 +21,29 @@ int	print_error_message(t_string message)
 		return (perror("Error"), FAILURE);
 	return (SUCCESS);
 }
+
+int	print_permission_denied_err(t_string file_path)
+{
+	int	result;
+	
+	result = print_error_message(file_path);
+	if (result != SUCCESS)
+		return (result);
+	result = print_error_message(": Permission denied\n");
+	if (result != SUCCESS)
+		return (result);
+	return (SUCCESS);
+}
+
+int	print_no_such_file_err(t_string file_path)
+{
+	int	result;
+
+	result = print_error_message(file_path);
+	if (result != SUCCESS)
+		return (result);
+	result = print_error_message(": No such file or directory\n");
+	if (result != SUCCESS)
+		return (result);
+	return (SUCCESS);
+}

--- a/src/helpers/error_printer.h
+++ b/src/helpers/error_printer.h
@@ -19,5 +19,7 @@
 # include <stdio.h>
 
 int	print_error_message(t_string message);
+int	print_permission_denied_err(t_string file_path);
+int	print_no_such_file_err(t_string file_path);
 
 #endif

--- a/src/logic/executor/command_runner/fds/file_processor.c
+++ b/src/logic/executor/command_runner/fds/file_processor.c
@@ -6,7 +6,7 @@
 /*   By: akovtune <akovtune@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/26 12:57:38 by akovtune          #+#    #+#             */
-/*   Updated: 2025/04/10 15:48:14 by akovtune         ###   ########.fr       */
+/*   Updated: 2025/04/10 17:41:18 by akovtune         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,6 +21,11 @@ int	process_file(t_file *file)
 {
 	int	result;
 
+	if (ft_strcmp(file->path, ""))
+	{
+		print_no_such_file_err(file->path);
+		return (EMPTY_FILE_PATH_ERR);
+	}
 	if (!check_file(file))
 		return (FILE_ACCESS_ERR);
 	result = open_file(file);
@@ -42,12 +47,10 @@ bool	check_input_file(t_file *file)
 		return (true);
 	if (access(file->path, F_OK) == 0)
 	{
-		print_error_message(file->path);
-		print_error_message(": Permission denied\n");
+		print_permission_denied_err(file->path);
 		return (false);
 	}
-	print_error_message(file->path);
-	print_error_message(": No such file or directory\n");
+	print_no_such_file_err(file->path);
 	return (false);
 }
 
@@ -59,8 +62,7 @@ bool	check_output_file(t_file *file)
 		return (true);
 	if (access(file->path, F_OK) == 0)
 	{
-		print_error_message(file->path);
-		print_error_message(": Permission denied\n");
+		print_permission_denied_err(file->path);
 		return (false);
 	}
 	if (!string_contains(file->path, "/"))
@@ -69,8 +71,7 @@ bool	check_output_file(t_file *file)
 	if (access(file_directory, F_OK) == 0)
 		return (destroy_string(&file_directory), true);
 	destroy_string(&file_directory);
-	print_error_message(file->path);
-	print_error_message(": No such file or directory\n");
+	print_no_such_file_err(file->path);
 	return (false);
 }
 

--- a/src/logic/executor/command_runner/fds/file_processor.h
+++ b/src/logic/executor/command_runner/fds/file_processor.h
@@ -6,7 +6,7 @@
 /*   By: akovtune <akovtune@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/06 16:37:20 by akovtune          #+#    #+#             */
-/*   Updated: 2025/04/06 16:50:25 by akovtune         ###   ########.fr       */
+/*   Updated: 2025/04/10 16:29:55 by akovtune         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,7 @@
 # include <stdbool.h>
 
 # define FILE_ACCESS_ERR 197
+# define EMPTY_FILE_PATH_ERR 198
 
 int	process_file(t_file *file);
 


### PR DESCRIPTION
Fixed error with the case where an output file is an empty string.
Added 2 more functions to the error_printer:
- print_permission_denied_err
- print_no_such_file_err